### PR TITLE
Fix Coroutine defer-in-defer behavior

### DIFF
--- a/src/Coroutine.php
+++ b/src/Coroutine.php
@@ -47,8 +47,8 @@ class Coroutine extends SwowCo implements CoroutineInterface
 
     public function __destruct()
     {
-        foreach ($this->deferCallbacks as $callback) {
-            $callback();
+        while (!empty($this->deferCallbacks)) {
+            array_shift($this->deferCallbacks)();
         }
     }
 

--- a/tests/Cases/CoroutineTest.php
+++ b/tests/Cases/CoroutineTest.php
@@ -125,20 +125,32 @@ class CoroutineTest extends AbstractTestCase
 
     public function testTheOrderForCoroutineDefer()
     {
-        $channel = new Channel(3);
+        // from FunctionTest.php in hyperf/utils
+        $channel = new Channel(10);
         Coroutine::create(function () use ($channel) {
             Coroutine::defer(function () use ($channel) {
-                $channel->push(2);
+                $channel->push(0);
             });
             Coroutine::defer(function () use ($channel) {
-                $channel->push(3);
+                $channel->push(1);
+                Coroutine::defer(function () use ($channel) {
+                    $channel->push(2);
+                });
+                Coroutine::defer(function () use ($channel) {
+                    $channel->push(3);
+                });
             });
-
-            $channel->push(1);
+            Coroutine::defer(function () use ($channel) {
+                $channel->push(4);
+            });
+            $channel->push(5);
         });
 
-        $this->assertSame(1, $channel->pop());
-        $this->assertSame(3, $channel->pop());
-        $this->assertSame(2, $channel->pop());
+        $this->assertSame(5, $channel->pop(0));
+        $this->assertSame(4, $channel->pop(0));
+        $this->assertSame(1, $channel->pop(0));
+        $this->assertSame(3, $channel->pop(0));
+        $this->assertSame(2, $channel->pop(0));
+        $this->assertSame(0, $channel->pop(0));
     }
 }


### PR DESCRIPTION
If we use Coroutine::defer in a defer callback, it will be ignored, this fixes its behavior.