### PR TITLE
🐛fix(server): waitAll should not handle in server start

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 composer.lock
 *.cache
 *.log
+.idea


### PR DESCRIPTION
在`Hyperf\Engine\Http\Server::start` 创建协程和waitAll，那么在 server close 后将提前堵塞住程序，导致无法触发`WORKER_EXIT`事件

在 vendor/hyperf/server/src/SwowServer.php:77 中 
```php
foreach ($servers as $name => [$type, $server]) {
    Coroutine::run(function () use ($name, $server, $config) {
        if (! $this->mainServerStarted) {
            $this->mainServerStarted = true;
            $this->eventDispatcher->dispatch(new MainCoroutineServerStart($name, $server, $config));
            CoordinatorManager::until(Constants::WORKER_START)->resume();
        }
        $this->eventDispatcher->dispatch(new CoroutineServerStart($name, $server, $config));
        $server->start(); // 如果在内部waitAll，则在第一个server close后，就永远不会释放  执行不了以下逻辑
        $this->eventDispatcher->dispatch(new CoroutineServerStop($name, $server));
        CoordinatorManager::until(Constants::WORKER_EXIT)->resume();
    });
}

if (CoordinatorManager::until(Constants::WORKER_EXIT)->yield()) {
    $this->closeAll($servers);
}

waitAll();
```