### PR TITLE
Fixed bug that `engine-swow` cannot work.

### DIFF
--- a/src/ResponseEmitter.php
+++ b/src/ResponseEmitter.php
@@ -42,8 +42,8 @@ class ResponseEmitter extends Emitter implements ResponseEmitterInterface
                 return;
             }
 
-            if ($response instanceof Response && $connection = $response->getConnection()) {
-                if ($connection instanceof WritableConnection && $connection->isSent()) {
+            if ($response instanceof Response && $writableConnection = $response->getConnection()) {
+                if ($writableConnection instanceof WritableConnection && $writableConnection->isSent()) {
                     return;
                 }
             }


### PR DESCRIPTION
镜像版本：`hyperf/hyperf:8.1-alpine-v3.16-swow-v1.5.3`

### 问题描述

Hyperf 启动后请求 HTTP 接口无响应，控制台无报错信息，调试后得到了以下错误信息：

```php
/swow-skeleton # php bin/hyperf.php start
[INFO] HTTP Coroutine Server listening at 0.0.0.0:9501
object(Hyperf\Coroutine\Exception\ExceptionThrower)#842 (1) {
  ["throwable":"Hyperf\Coroutine\Exception\ExceptionThrower":private]=>
  object(Error)#825 (7) {
    ["message":protected]=>
    string(82) "Call to undefined method Hyperf\Engine\Http\WritableConnection::sendHttpResponse()"
    ["string":"Error":private]=>
    string(0) ""
    ["code":protected]=>
    int(0)
    ["file":protected]=>
    string(64) "/swow-skeleton/vendor/hyperf/engine-swow/src/ResponseEmitter.php"
    ["line":protected]=>
    int(69)
    ["trace":"Error":private]=>
    array(15) {
      [0]=>
      array(5) {
        ["file"]=>
        string(55) "/swow-skeleton/vendor/hyperf/http-server/src/Server.php"
        ["line"]=>
        int(144)
        ["function"]=>
        string(4) "emit"
        ["class"]=>
        string(29) "Hyperf\Engine\ResponseEmitter"
        ["type"]=>
        string(2) "->"
      }
      [1]=>
      array(5) {
        ["file"]=>
        string(54) "/swow-skeleton/vendor/hyperf/server/src/SwowServer.php"
        ["line"]=>
        int(143)
        ["function"]=>
        string(9) "onRequest"
        ["class"]=>
        string(24) "Hyperf\HttpServer\Server"
        ["type"]=>
        string(2) "->"
      }
      [2]=>
      array(5) {
        ["file"]=>
        string(53) "/swow-skeleton/vendor/hyperf/coroutine/src/Waiter.php"
        ["line"]=>
        int(48)
        ["function"]=>
        string(23) "Hyperf\Server\{closure}"
        ["class"]=>
        string(24) "Hyperf\Server\SwowServer"
        ["type"]=>
        string(2) "::"
      }
```

### 问题原因

在 `ResponseEmitter::emit` 方法中，`$connection` 变量原本是 `Swow\Psr7\Server\ServerConnection ` 对象，但是在 45 行代码重写了 `$connection` 变量，变成了 `Hyperf\Engine\Http\WritableConnection` 对象。当 `iSent` 方法返回 `false` 时，执行 `$connection->sendHttpResponse($response)` 就会出现异常。

[Fixed bug that EventStream cannot work as excepted.](https://github.com/hyperf/engine-swow/commit/758327ba0980ac758983fdff51f74798e99b652d) 这个 commit 之后的版本应该都存在这个问题。

### 复现步骤

启动 Hyperf：

```bash
docker run --rm -it -p 9501:9501 hyperf/hyperf:8.1-alpine-v3.16-swow-v1.5.3 sh -c "composer create-project hyperf/swow-skeleton && cd ./swow-skeleton && php bin/hyperf.php start"
```

请求 HTTP 接口：

```
curl -v 127.0.0.1:9501
*   Trying 127.0.0.1:9501...
* Connected to 127.0.0.1 (127.0.0.1) port 9501
> GET / HTTP/1.1
> Host: 127.0.0.1:9501
> User-Agent: curl/8.4.0
> Accept: */*
>
* Empty reply from server
* Closing connection
curl: (52) Empty reply from server
```


