### PR TITLE
Fix swow version constraint to allow 2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "require": {
         "php": ">=8.0",
         "hyperf/engine-contract": "~1.14.0",
-        "swow/swow": "^1.7"
+        "swow/swow": "^1.7 || ^2.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.0",


### PR DESCRIPTION
ProcessManager and WorkerContext were introduced in Swow 2.0.

The previous constraint `^1.7` excludes 2.x entirely due to semver semantics (`>=1.7.0 <2.0.0`), making it impossible to install the required classes added in #41.

This changes the constraint to `^1.7 || ^2.0` to support both 1.7+ and 2.0+.